### PR TITLE
fix: resolve invalid kpsdk-cd d value generation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,14 @@ const part1 = require('./modules/part-1.js');
 const part2 = require('./modules/part-2.js');
 
 (async () => {
-  // obtains the KPSDK message
-  const message = await part1();
+  // obtains KPSDK.message
+  const {
+    endTime,
+    message
+  } = await part1();
   
   // processes the KPSDK message to return ct (client token), cd (challenge data), and v (version) headers
-  const kpsdk = part2(message);
+  const kpsdk = part2(message, endTime);
   
   console.log(kpsdk);
 })();

--- a/src/modules/part-1.js
+++ b/src/modules/part-1.js
@@ -22,8 +22,14 @@ module.exports = async function () {
     document.body.append(iframe);
   });
   
-  const message = await new Promise(resolve => page.once('pageerror', ({ message }) => resolve(message)));
+  const
+    message = await new Promise(resolve => page.once('pageerror', ({ message }) => resolve(message))),
+    endTime = Date.now();
   
   await browser.close();
-  return message;
+  
+  return {
+    endTime,
+    message
+  };
 }

--- a/src/modules/part-2.js
+++ b/src/modules/part-2.js
@@ -38,7 +38,7 @@ const {
   solveChallenge
 } = _0x3fa0dc(8145 || 0x1fd1).challengeModuleV2();
 
-module.exports = function(message) {
+module.exports = function(message, timestamp = Date.now()) {
   const {
     cryptoChallengeEnabled,
     encodedClientToken,
@@ -46,7 +46,7 @@ module.exports = function(message) {
     serverTime
   } = parseSDKMessage(message);
 
-  addServerOffset(Date.now(), serverTime);
+  addServerOffset(timestamp, serverTime);
 
   return {
     cd: JSON.stringify(solveChallenge(requestChallengeSync())),


### PR DESCRIPTION
This introduces an optional transport of the timestamp when `KPSDK.message` is received, which fixes the generation of an invalid `d` value of the `kpsdk-cd` object.
<hr>

**Sample 1**
`kpsdk-cd` generated on sdk.vercel.ai (is definitely valid)
```json
{"workTime":1706322888088,"id":"c3e7364b593d0b8420fceaa3afc6121f","answers":[6,10],"duration":1.5,"d":-303,"st":1706322883907,"rst":1706322883604}
```

**Sample 2**
`kpsdk-cd` generated by kpsdk-solver; Firefox + Playwright on sdk.vercel.ai
```json
{"workTime":1706322897309,"id":"15dcc5829fccbda0ba262325744b8f7b","answers":[8,3],"duration":2.449,"d":615,"st":1706322897309,"rst": 1706322897924}
```

These samples were taken at approximately the same time. Despite observing gradual changes in the range of `d`, the change should not be as significant in such a short period.

After some analysis, I found that a minor delay caused by the asynchronous [`browser.close()`](https://github.com/0x6a69616e/kpsdk-solver/blob/6617de9c8dbf08be9290c56672182a0c6630ef1e/src/modules/part-1.js#L27) resulted in an "invalid" `d` value. This delay is apparent by the few hundred millisecond difference between the two samples' values of `d`.

<br>

> *Despite observing gradual changes in the range of `d`, the change should not be as significant in such a short period.*

> *..."invalid" `d` value.*

It is observed that `d` maintains some hidden valid range or baseline value that eventually changes in the span of a few hours. This is most likely one of Kasada's timing checks.

Additionally, it is worth noting that `d` can be calculated as `rst` - `st`, where `st` represents the `serverTime` provided by `KPSDK.message`, and `rst` represents the timestamp when parsing of the `KPSDK.message` was completed.