### PR TITLE
fix: refresh fp iframe to receive a status 200 instead of a 429

### DIFF
--- a/src/modules/part-1.js
+++ b/src/modules/part-1.js
@@ -1,10 +1,12 @@
 const { firefox } = require('playwright');
 
 module.exports = async function () {
-  const browser = await firefox.launch({
-    headless: true
-  });
-  const page = await browser.newPage();
+  const
+    browser = await firefox.launch({
+      headless: true
+    }),
+    context = await browser.newContext(),
+    page = await context.newPage();
   
   await page.goto('about:blank');
   
@@ -18,9 +20,14 @@ module.exports = async function () {
     
     iframe.style.width = iframe.style.height = iframe.style.border = '0';
     iframe.style.display = 'none';
+    iframe.id = 'iframe';
     
     document.body.append(iframe);
   });
+  
+  await new Promise(resolve => page.once('pageerror', resolve));
+  
+  await page.evaluate(() => document.getElementById('iframe').src = document.getElementById('iframe').src);
   
   const
     message = await new Promise(resolve => page.once('pageerror', ({ message }) => resolve(message))),


### PR DESCRIPTION
[streamlink/streamlink#5370 (comment)](https://github.com/streamlink/streamlink/issues/5370#issuecomment-1582806603)

> 2. `passport.twitch.tv/.../fp` gets requested and if no cookies from (3) are sent, it results in a 429 HTTP status code and another obfuscated JS script. This script contains string-encoded bytecode (~250 KiB) for a custom JS virtual machine that is then run, which is really complicated. I stepped through some of it where it interprets individual bytecode instructions and reads data from the bytecode, and I found a couple of things, like a block-encryption algorithm with a 128-bit key and 64-bit IV and lots of object+property names that are all related to browser-fingerprinting.
> 3. Once that script succeeds, it requests `passport.twitch.tv/.../tl` with a large binary `POST` body and the response to this are the `KP_UIDz` and `ga__12_abel` cookies which are probably valid for a longer time (didn't check).
> 4. `passport.twitch.tv/.../fp` gets requested again and with the right cookies it now returns status code 200 with a `KPSDK.message` string.

It appears that we need to refresh the `/fp` iframe to get a status 200 instead of a 429?